### PR TITLE
build: update group id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 defaultTasks("build", "test", "shadowJar")
 
 allprojects {
-    group = "org.aero"
+    group = "org.aero.common"
     version = "1.0.0-SNAPSHOT"
     description = "A common core library"
 

--- a/event/build.gradle.kts
+++ b/event/build.gradle.kts
@@ -29,5 +29,5 @@ tasks.withType<ShadowJar> {
 }
 
 dependencies {
-    implementation(project(":core"))
+    "implementation"(projects.core)
 }

--- a/task/build.gradle.kts
+++ b/task/build.gradle.kts
@@ -29,5 +29,5 @@ tasks.withType<ShadowJar> {
 }
 
 dependencies {
-    implementation(project(":core"))
+    "implementation"(projects.core)
 }


### PR DESCRIPTION
### Motivation
Currently it is not possible to distinguish between different projects in mavne repositories and therefore it is not possible to create modules with the same name in different projects.

### Modification
Changed the group id to org.aero.common so that it contains the project name.

### Result
Now you can distinguish between different projects by the group id and have modules with the same name in this one, because the group id is unique.
